### PR TITLE
List containers example in Readme missing a line

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ import grpc
 from containerd.services.containers.v1 import containers_pb2_grpc, containers_pb2
 
 with grpc.insecure_channel('unix:///run/containerd/containerd.sock') as channel:
+    containersv1 = containers_pb2_grpc.ContainersStub(channel)
     containers = containersv1.List(
         containers_pb2.ListContainersRequest(),
         metadata=(('containerd-namespace', 'moby'),)).containers


### PR DESCRIPTION
The "List Containers in a Specific Namespace" example needs to initialize `containersv1` before it is used.