### PR TITLE
show namespaces of events, fix import for Python 3.6 and older

### DIFF
--- a/examples/watchctr.py
+++ b/examples/watchctr.py
@@ -36,6 +36,7 @@ def watchctr(args):
         eventsv1 = events_pb2_grpc.EventsStub(channel)
         for ev in eventsv1.Subscribe(events_pb2.SubscribeRequest()):
             print('🖄 event type:', ev.event.type_url)
+            print('⬚ namespace:', ev.namespace)
             print(unwrap(ev))
 
 def main():

--- a/resources/containerd/services/events/v1/__init__.py
+++ b/resources/containerd/services/events/v1/__init__.py
@@ -1,6 +1,8 @@
 import importlib
 import google.protobuf.symbol_database
-import containerd.services.events.v1.events_pb2 as eventsv1
+# use "from ... import ... as ..." instead of "import ... as ..." for backwards
+# compatibility with Python 3.6-, see also https://stackoverflow.com/a/24968941
+from containerd.services.events.v1 import events_pb2 as eventsv1
 
 # Loads all containerd.events.xxx modules, so they will register their message
 # classes with their corresponding type URLs. Only then we can then later look


### PR DESCRIPTION
1. containerd organizes containers, tasks, etc. into namespaces (no, _no_, _no-no-no_, not _those_ namespaces, these are different ones!), so its events are also properly namespace'd. This PR updates the event watcher example to additionally show the namespace the particular event originated in.
2. fixes issue #8 (failing import).