### PR TITLE
Prevent possible code injection in deploy job

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -19,9 +19,11 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
+      env:
+        INPUT_VERSION: ${{ github.event.inputs.version }}
       run: |
         if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] ; then \
-          RELEASE_VERSION="${{ github.event.inputs.version }}" ; \
+          RELEASE_VERSION="${INPUT_VERSION}" ; \
         elif [[ "${GITHUB_EVENT_NAME}" == "release" ]] ; then \
           RELEASE_VERSION="$(echo ${GITHUB_REF##refs/tags/v} | sed 's/\([[:digit:]]\+\.[[:digit:]]\+\)\.[[:digit:]]\+/\1/g')" ; \
         else \
@@ -34,9 +36,10 @@ jobs:
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        INPUT_VERSION: ${{ github.event.inputs.version }}
       run: |
         if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] ; then \
-          RELEASE_VERSION="${{ github.event.inputs.version }}" ; \
+          RELEASE_VERSION="${INPUT_VERSION}" ; \
         elif [[ "${GITHUB_EVENT_NAME}" == "release" ]] ; then \
           RELEASE_VERSION="$(echo ${GITHUB_REF##refs/tags/v} | sed 's/\([[:digit:]]\+\.[[:digit:]]\+\)\.[[:digit:]]\+/\1/g')" ; \
         else \


### PR DESCRIPTION
The deploy job directly uses a input variable, making it possible
to inject code in the job. The risk here is quite low, because it is
only ran when the pipeline is triggered explicitely. But nevertheless
it's good to follow best practices. 

Discovered by a Poutine scan, see
https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/injection.md.